### PR TITLE
update workshop, dont need DynamoDB lock table anymore

### DIFF
--- a/remote-state/stack.yaml
+++ b/remote-state/stack.yaml
@@ -5,10 +5,6 @@ Parameters:
     Description: Name prefix of the state bucket
     Type: String
     Default: YOUR-NAME-terraform-workshop-state-bucket
-  LockTableName:
-    Description: Name of the lock table
-    Type: String
-    Default: YOUR-NAME-terraform-workshop-lock-table
 
 Resources:
   StateBucket:
@@ -26,18 +22,6 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
-
-  LockTable:
-    Type: AWS::DynamoDB::Table
-    Properties:
-      TableName: !Ref LockTableName
-      AttributeDefinitions:
-        - AttributeName: LockID
-          AttributeType: S
-      KeySchema:
-        - AttributeName: LockID
-          KeyType: HASH
-      BillingMode: PAY_PER_REQUEST
 
 Outputs:
   StateBucket:

--- a/solution/terraform.tf
+++ b/solution/terraform.tf
@@ -1,20 +1,21 @@
 terraform {
-  required_version = "~> 1.7.4"
+  required_version = "~> 1.11.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.40.0"
+      version = ">= 5.96.0"
     }
   }
 
   backend "s3" {
-    workspace_key_prefix = "[YOUR-NAME]-devops-represent-terraform-workshop"
+    workspace_key_prefix = "[YOUR-NAME]-terraform-workshop"
+    region               = "ap-southeast-2"
+    bucket               = "[YOUR-NAME]-terraform-workshop-state-bucket-[AWS-ACCOUNT-ID]"
+    key                  = "terraform.tfstate"
+    use_lockfile         = true
   }
-
 }
-
-
 
 provider "aws" {
   region = "ap-southeast-2"

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,11 +10,12 @@ terraform {
 
   backend "s3" {
     workspace_key_prefix = "[YOUR-NAME]-terraform-workshop"
+    region               = "ap-southeast-2"
+    bucket               = "[YOUR-NAME]-terraform-workshop-state-bucket-[AWS-ACCOUNT-ID]"
+    key                  = "terraform.tfstate"
+    use_lockfile         = true
   }
-
 }
-
-
 
 provider "aws" {
   region = "ap-southeast-2"

--- a/workshop-content/04-remote-state-set-up.md
+++ b/workshop-content/04-remote-state-set-up.md
@@ -8,7 +8,7 @@ We're going to deploy these resources using Cloudformation in `ap-southeast-2` S
 
 The Cloudformation template we're using can be found [HERE](../remote-state/stack.yaml).
 
-This [template](../remote-state/stack.yaml) provisions a CloudFormation stack in ap-southeast-2 that contains a S3 bucket named [YOUR-NAME]-terraform-workshop-state-bucket-XXXXX where XXXXX is the ID of the AWS account, as well as a DynamoDB lock table.
+This [template](../remote-state/stack.yaml) provisions a CloudFormation stack in ap-southeast-2 that contains a S3 bucket named [YOUR-NAME]-terraform-workshop-state-bucket-XXXXX where XXXXX is the ID of the AWS account.
 
 To deploy this stack we can log into the AWS Console and follow these steps:
 
@@ -21,26 +21,23 @@ To deploy this stack we can log into the AWS Console and follow these steps:
 7. Select your locally saved file `/remote-state/stack.yaml`
 8. Click `Next`
 9. Give your stack a name `[YOUR-NAME]-terraform-workshop`
-10. Rename your `LockTableName` and `StateBucketNamePrefix` parameters (eg. `LockTableName = franca-terraform-workshop-lock-table`, `StateBucketNamePrefix = franca-terraform-workshop-state-bucket`)
+10. Rename your `StateBucketNamePrefix` parameters (eg. `StateBucketNamePrefix = franca-terraform-workshop-state-bucket`)
 11. Click `Next`
 12. Click `Next`
 13. Click `Submit`
 
-Great job! You've deployed an s3 Bucket and DynamoDB Table to host your state. 
+Great job! You've deployed an s3 Bucket to host your state.
 
-You may need to wait a couple of minutes until these resources are fully deployed to continue. 
+You may need to wait a couple of minutes until these resources are fully deployed to continue.
 Your Cloudformation stack should show `status: CREATE_COMPLETE`
 
 ## How does this work though?
 
 Remote state in Terraform deployed this way uses the following resources:
 
-*S3 Bucket* - Stores the state of your terraform stack
-
-*DynamoDB Table*  - Database used for State Locking and Consistency Checking.
-This prevents people from making concurrent changes to a stack. 
+_S3 Bucket_ - Stores the state of your terraform stack.
+With terraform versions `1.10` and above, it also provides native state locking preventing people from making concurrent changes to a stack.
 
 ![remote-state](../images/s3-remote-state.png)
-
 
 ## [NEXT SECTION - Command Line 👉🏽](05-command-line.md)

--- a/workshop-content/05-command-line.md
+++ b/workshop-content/05-command-line.md
@@ -29,13 +29,22 @@ terraform {
 
   backend "s3" {
     workspace_key_prefix = "[YOUR-NAME]-terraform-workshop"
+    region               = "ap-southeast-2"
+    bucket               = "[YOUR-NAME]-terraform-workshop-state-bucket-[AWS-ACCOUNT-ID]"
+    key                  = "terraform.tfstate"
+    use_lockfile         = true
   }
-
 }
 
 ```
 
 Where `XXXX` appears, we need to fill in with some information:
+
+Let's use the AWS CLI to get your AWS account ID to make your bucketname unique.
+
+```bash
+export account_id=$(aws sts get-caller-identity --query Account --output text)
+```
 
 Run the following command to find out what version of Terraform you're working with:
 
@@ -46,12 +55,12 @@ Run the following command to find out what version of Terraform you're working w
 Example output:
 
 ```
-Terraform v1.7.4
+Terraform v1.11.4
 on darwin_arm64
 + provider registry.terraform.io/hashicorp/aws v5.40.0
 ```
 
-In this example, replace `XXXX` in `required_version` with `1.7.4` and in `version` with `5.40.0`
+In this example, replace `XXXX` in `required_version` with `1.11.4` and in `version` with `5.40.0`
 
 To find out the LATEST version of:
 
@@ -66,23 +75,10 @@ Through a combination of AWS magic and some set variables, we're going to initia
 
 Open up your command line tool.
 
-Let's use the AWS CLI to get your AWS account ID to make your bucketname unique and set the region to Sydney.
-
-```bash
-export account_id=$(aws sts get-caller-identity --query Account --output text)
-export global_region=ap-southeast-2
-```
-
 Now we're going to run the `terraform init` command to configure the backend by mapping to the resources we've created in our [remote-state-set-up](04-remote-state-set-up.md) steps.
 
-Remember to replace `[YOUR-NAME]` with the name you used when creating the remote state stack (in the AWS console).
-
 ```bash
-terraform init \
-  -backend-config=region=$global_region \
-  -backend-config=bucket=[YOUR-NAME]-terraform-workshop-state-bucket-$account_id \
-  -backend-config=key=terraform.tfstate \
-  -backend-config=dynamodb_table=[YOUR-NAME]-terraform-workshop-lock-table
+terraform init
 ```
 
 ---
@@ -114,16 +110,6 @@ This should show your new workspace. The `*` denotes which workspace you're usin
 ---
 
 <details><summary>Troubleshooting Tips</summary><p>
-
-You'll face some issues if your initialization details don't match your backend you've created:
-
-This needs to match the **s3 Bucket** you created in your [Remote State Stack](../remote_state/stack.yaml)
-
-`-backend-config=bucket=[YOUR-NAME]-terraform-workshop-lock-table-$account_id \`
-
-This needs to match the **DynamoDB table** name you created in your [Remote State Stack](../remote_state/stack.yaml)
-
-`-backend-config=dynamodb_table=[YOUR-NAME]-terraform-workshop-lock-table`
 
 If you've had some issues already and the `terraform-init` command is telling you the bucket doesn't exist, try the following command to remove th state lock file:
 

--- a/workshop-content/07-deploy-update-destroy.md
+++ b/workshop-content/07-deploy-update-destroy.md
@@ -102,11 +102,10 @@ Now that you have an s3 bucket and policy set up for web hosting, you'll need to
 
 #### Using the command line:
 
-- navigate to the website_files folder in this repo - `cd website_files`
 - sync the contents of this folder with your s3 bucket:
 
 ```
-aws s3 sync . s3://yourbucketnamehere
+aws s3 sync website_files s3://yourbucketnamehere
 ```
 
 #### Using the console:
@@ -127,8 +126,6 @@ _If you want to deploy your prod stack just update the name of the tfvars file f
 ## Terraform Destroy
 
 Now that it's time to clean up our work, let's destroy our stack! If you ever want to get your stack back, that is the beauty of infrastructure as code - you can easily re-deploy it exactly as it was before.
-
-Remember to first `cd ..` out of your `website_files` directory.
 
 To clean up your account, run the following command:
 


### PR DESCRIPTION
- We don't need the lock table anymore, as with terraform version >=1.10, s3 backend has native lock.
- simplify `terraform init` command by putting it into config instead